### PR TITLE
Bump Kyuubi 1.6.0-incubating

### DIFF
--- a/plugin/jdbc/kyuubi/pom.xml
+++ b/plugin/jdbc/kyuubi/pom.xml
@@ -13,7 +13,7 @@
     <name>DataCap plugin for jdbc (Kyuubi)</name>
 
     <properties>
-        <kyuubi-jdbc.version>1.5.2-incubating</kyuubi-jdbc.version>
+        <kyuubi-jdbc.version>1.6.0-incubating</kyuubi-jdbc.version>
         <plugin.name>jdbc-kyuubi</plugin.name>
     </properties>
 


### PR DESCRIPTION
**Changelog category (leave one)**

- Other

**Changelog entry (Details of this change)**

Bump Kyuubi from 1.5.2-incubating to 1.6.0-incubating.

1.6.0-incubating is the latest stable version[1], there are no breaking changes affecting users who use standard JDBC API.

[1] https://kyuubi.apache.org/releases.html

**Affected version**

`latest version`
